### PR TITLE
Update to v3.1.1 and add VCID fixer

### DIFF
--- a/aws_pre_proc_container/Dockerfile
+++ b/aws_pre_proc_container/Dockerfile
@@ -1,56 +1,27 @@
 FROM ubuntu:20.04 as builder
 
 WORKDIR /opt
-COPY aws-ipf-v2.0.0-repackaged-20230822.tar.7z /opt
+COPY v3.1.1.zip /opt
 
 RUN apt update -y \
     && TZ="UTC" apt install -y tzdata \
-    && apt install -y build-essential \
-       rsync \
-       p7zip-full \
-       cmake \
-       valgrind \
-       git \
-       python3 \
-       python3-pip \
-       libnetcdf-c++4-dev \
-       libfmt-dev \
-       libspdlog-dev \
-       libpugixml-dev \
-       libboost-dev \
-       libgomp1 \
-       libopenblas-dev \
-       liblapack-dev \
-       libpugixml1v5 \
-       libnetcdf15 \
-       libnetcdf-c++4-1 \
-       libgomp1 \
-       libopenblas0 \
-       liblapack3 \
-    && pip3 install cpplint
+    && apt install -y unzip
 
-RUN cd /opt \
-    && 7z x aws-ipf-v2.0.0-repackaged-20230822.tar.7z \
-    && tar xvvf aws-ipf-v2.0.0-repackaged-20230822.tar \
-    && mv /opt/aws-ipf-v2.0.0-repackaged-20230822/ /opt/aws/ \
-    && cd /opt/aws/COTS/CPPEOCFI/V4.25/libraries/LINUX64/ \
-    && rm libproj.so.14 \
-    && ln -s libproj.so.14.0.2 libproj.so.14 \
-    && /opt/aws/support/scripts/build.sh
-
-RUN cd /opt/aws \
-    && mkdir for_container \
-    && mkdir AWSat \
-    && mv lib/ bin/ conf/ ADF/ AWSat/ for_container/
+RUN mkdir -p /opt/aws/AWSat \
+    && cd /opt \
+    && unzip v3.1.1.zip \
+    && mkdir /opt/aws/for_container \
+    && mv v3.1.1/* /opt/aws/for_container/
 
 COPY JobOrder_L0_template.xml /opt/aws/for_container/AWSat/JobOrder_L0_template.xml
 COPY JobOrder_L1_template.xml /opt/aws/for_container/AWSat/JobOrder_L1_template.xml
-COPY create_awsat_joborder.py /opt/aws/for_container/AWSat/
+COPY create_awsat_joborder.py /opt/aws/for_container/bin/
+COPY DSDB_VCID_replace.py /opt/aws/for_container/bin/
 
 FROM ubuntu:20.04
 
 RUN apt-get update -y \
-    && apt install -y p7zip-full \
+    && apt install -y \
        libpugixml1v5 \
        libnetcdf15 \
        libnetcdf-c++4-1 \
@@ -60,4 +31,5 @@ RUN apt-get update -y \
 
 COPY --from=builder /opt/aws/for_container /opt/aws/
 COPY entrypoint.sh /opt/aws/bin/
+
 ENTRYPOINT ["/opt/aws/bin/entrypoint.sh"]

--- a/aws_pre_proc_container/JobOrder_L0_template.xml
+++ b/aws_pre_proc_container/JobOrder_L0_template.xml
@@ -1,109 +1,46 @@
+<?xml version="1.0" ?>
 <Ipf_Job_Order>
-    <Ipf_Conf>
-        <Processor_Name>IPF-AWS-L0</Processor_Name>
-        <Version>02.00</Version>
-        <Log_Level>INFO</Log_Level>
-        <Test>false</Test>
-        <Breakpoint_Enable>false</Breakpoint_Enable>
-        <Acquisition_Station></Acquisition_Station>
-        <Processing_Station>PM</Processing_Station>
-        <Config_Files count="1">
-            <Conf_File_Name>conf/L0/AWS_L0_Configuration.xml</Conf_File_Name>
-        </Config_Files>
-		<Dynamic_Processing_Parameters count="9">
-			<Processing_Parameter>
-				<Name>spacecraft</Name>
-				<Value>AWS1</Value>
-			</Processing_Parameter>
-			<Processing_Parameter>
-				<Name>mission_type</Name>
-				<Value>G</Value>
-			</Processing_Parameter>
-			<Processing_Parameter>
-				<Name>disposition_mode</Name>
-				<Value>T</Value>
-			</Processing_Parameter>
-			<Processing_Parameter>
-				<Name>environment</Name>
-				<Value>D</Value>
-			</Processing_Parameter>
-			<Processing_Parameter>
-				<Name>organization</Name>
-				<Value>OHB</Value>
-			</Processing_Parameter>
-			<Processing_Parameter>
-				<Name>location</Name>
-				<Value>Stockholm</Value>
-			</Processing_Parameter>
-			<Processing_Parameter>
-				<Name>oflag</Name>
-				<Value>C</Value>
-			</Processing_Parameter>
-			<Processing_Parameter>
-				<Name>originator</Name>
-				<Value>OHB</Value>
-			</Processing_Parameter>
-			<Processing_Parameter>
-				<Name>processing_mode</Name>
-				<Value>B</Value>
-			</Processing_Parameter>
-		</Dynamic_Processing_Parameters>
-    </Ipf_Conf>
-    <List_of_Ipf_Procs count="1">
-        <Ipf_Proc>
-            <Task_Name>IPF-AWS-L0</Task_Name>
-            <Task_Version>02.00</Task_Version>
-            <List_of_Inputs count="2">
-                <!-- Auxiliary Input Files -->
-                <Input>
-                    <File_Type>AX__BB_AX</File_Type>
-                    <File_Name_Type>Physical</File_Name_Type>
-                    <List_of_File_Names count="1">
-                        <File_Name>ADF/AWS_AUX_DATA/GeoData/iers_bulletin_b_11_2007.txt</File_Name>
-                    </List_of_File_Names>
-                </Input>
-                <!-- Raw Data Input Files -->
-                <Input>
-                    <File_Type>DCS_02_0X068___</File_Type>
-                    <File_Name_Type>Physical</File_Name_Type>
-                    <List_of_File_Names count="20">
-			<File_Name>test-data/inputs/DCS_02_0X068_20230807113901_vc2_DSDB_0001.raw</File_Name>
-			<File_Name>test-data/inputs/DCS_02_0X068_20230807113901_vc2_DSDB_0002.raw</File_Name>
-			<File_Name>test-data/inputs/DCS_02_0X068_20230807113901_vc2_DSDB_0003.raw</File_Name>
-			<File_Name>test-data/inputs/DCS_02_0X068_20230807113901_vc2_DSDB_0004.raw</File_Name>
-			<File_Name>test-data/inputs/DCS_02_0X068_20230807113901_vc2_DSDB_0005.raw</File_Name>
-			<File_Name>test-data/inputs/DCS_02_0X068_20230807113901_vc2_DSDB_0006.raw</File_Name>
-			<File_Name>test-data/inputs/DCS_02_0X068_20230807113901_vc2_DSDB_0007.raw</File_Name>
-			<File_Name>test-data/inputs/DCS_02_0X068_20230807113901_vc2_DSDB_0008.raw</File_Name>
-			<File_Name>test-data/inputs/DCS_02_0X068_20230807113901_vc2_DSDB_0009.raw</File_Name>
-			<File_Name>test-data/inputs/DCS_02_0X068_20230807113901_vc2_DSDB_0010.raw</File_Name>
-			<File_Name>test-data/inputs/DCS_02_0X068_20230807113901_vc2_DSDB_0011.raw</File_Name>
-			<File_Name>test-data/inputs/DCS_02_0X068_20230807113901_vc2_DSDB_0012.raw</File_Name>
-			<File_Name>test-data/inputs/DCS_02_0X068_20230807113901_vc2_DSDB_0013.raw</File_Name>
-			<File_Name>test-data/inputs/DCS_02_0X068_20230807113901_vc2_DSDB_0014.raw</File_Name>
-			<File_Name>test-data/inputs/DCS_02_0X068_20230807113901_vc2_DSDB_0015.raw</File_Name>
-			<File_Name>test-data/inputs/DCS_02_0X068_20230807113901_vc2_DSDB_0016.raw</File_Name>
-			<File_Name>test-data/inputs/DCS_02_0X068_20230807113901_vc2_DSDB_0017.raw</File_Name>
-			<File_Name>test-data/inputs/DCS_02_0X068_20230807113901_vc2_DSDB_0018.raw</File_Name>
-			<File_Name>test-data/inputs/DCS_02_0X068_20230807113901_vc2_DSDB_0019.raw</File_Name>
-			<File_Name>test-data/inputs/DCS_02_0X068_20230807113901_vc2_DSDB_0020.raw</File_Name>
-                    </List_of_File_Names>
-                </Input>
-            </List_of_Inputs>
-            <List_of_Outputs count="2">
-                <Output>
-                    <File_Type>SRC_NAV_00</File_Type>
-                    <File_Name_Type>Physical</File_Name_Type>
-                    <!-- This field should specify an output folder, because the filename will be dynamic (with timestamp)-->
-		    <File_Name>/tmp/</File_Name>
-                </Output>
-                <Output>
-                    <File_Type>SRC_AWS_00</File_Type>
-                    <File_Name_Type>Physical</File_Name_Type>
-                    <!-- This field should specify an output folder, because the filename will be dynamic (with timestamp)-->
-		    <File_Name>/tmp/</File_Name>
-                </Output>
-            </List_of_Outputs>
-        </Ipf_Proc>
-    </List_of_Ipf_Procs>
+  <Ipf_Conf>
+    <Processor_Name>IPF-AWS-L0</Processor_Name>
+    <Version>01.00</Version>
+    <Stdout_Log_Level>INFO</Stdout_Log_Level>
+    <Stderr_Log_Level>PROGRESS</Stderr_Log_Level>
+    <Test>false</Test>
+    <Breakpoint_Enable>false</Breakpoint_Enable>
+    <Processing_Station>SOD</Processing_Station>
+    <Config_Files count="1">
+      <Conf_File_Name>/opt/aws/conf/L0/AWS_L0_Configuration.xml</Conf_File_Name>
+    </Config_Files>
+    <!--Sensing_Time>
+      <Start>20250206_163403000000</Start>
+      <Stop>20250206_182403000000</Stop>
+    </Sensing_Time-->
+  </Ipf_Conf>
+  <List_of_Ipf_Procs count="1">
+    <Ipf_Proc>
+      <Task_Name>IPF-AWS-L0</Task_Name>
+      <Task_Version>01.00</Task_Version>
+      <List_of_Inputs count="1">
+        <Input>
+          <File_Type>DCS_02_0X068___</File_Type>
+          <File_Name_Type>Physical</File_Name_Type>
+          <List_of_File_Names count="1">
+            <File_Name>/home/mlange/Data/RAW/20250206/DCS_02_0X068_20250206181403_dat/DCS_02_0X068_20250206181403_vc2_DSDB_0001.raw</File_Name>
+          </List_of_File_Names>
+        </Input>
+      </List_of_Inputs>
+      <List_of_Outputs count="2">
+        <Output>
+          <File_Type>SRC_NAV_00</File_Type>
+          <File_Name_Type>Directory</File_Name_Type>
+          <File_Name>/tmp/</File_Name>
+        </Output>
+        <Output>
+          <File_Type>SRC_AWS_00</File_Type>
+          <File_Name_Type>Directory</File_Name_Type>
+          <File_Name>/tmp/</File_Name>
+        </Output>
+      </List_of_Outputs>
+    </Ipf_Proc>
+  </List_of_Ipf_Procs>
 </Ipf_Job_Order>

--- a/aws_pre_proc_container/JobOrder_L1_template.xml
+++ b/aws_pre_proc_container/JobOrder_L1_template.xml
@@ -1,101 +1,48 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Ipf_Job_Order xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:functx="http://www.functx.com" xmlns:csw="http://www.deimos-space.com/csw4eo/csw">
-	<Ipf_Conf>
-		<Processor_Name>IPF-AWS-L1</Processor_Name>
-		<Version>02.00</Version>
-		<Stdout_Log_Level>INFO</Stdout_Log_Level>
-		<Stderr_Log_Level>PROGRESS</Stderr_Log_Level>
-        <Test>false</Test>
-		<Breakpoint_Enable>false</Breakpoint_Enable>
-		<Processing_Station>MPC</Processing_Station>
-		<Config_Files count="1">
-            <Conf_File_Name>conf/L1/AWS_L1_Configuration.xml</Conf_File_Name>
-        </Config_Files>
-		<Dynamic_Processing_Parameters count="9">
-			<Processing_Parameter>
-				<Name>spacecraft</Name>
-				<Value>AWS1</Value>
-			</Processing_Parameter>
-			<Processing_Parameter>
-				<Name>mission_type</Name>
-				<Value>G</Value>
-			</Processing_Parameter>
-			<Processing_Parameter>
-				<Name>disposition_mode</Name>
-				<Value>T</Value>
-			</Processing_Parameter>
-			<Processing_Parameter>
-				<Name>environment</Name>
-				<Value>D</Value>
-			</Processing_Parameter>
-			<Processing_Parameter>
-				<Name>organization</Name>
-				<Value>OHB</Value>
-			</Processing_Parameter>
-			<Processing_Parameter>
-				<Name>location</Name>
-				<Value>Stockholm</Value>
-			</Processing_Parameter>
-			<Processing_Parameter>
-				<Name>oflag</Name>
-				<Value>C</Value>
-			</Processing_Parameter>
-			<Processing_Parameter>
-				<Name>originator</Name>
-				<Value>OHB</Value>
-			</Processing_Parameter>
-			<Processing_Parameter>
-				<Name>processing_mode</Name>
-				<Value>B</Value>
-			</Processing_Parameter>
-		</Dynamic_Processing_Parameters>
-	</Ipf_Conf>
-	<List_of_Ipf_Procs count="1">
-		<Ipf_Proc>
-			<Task_Name>IPF-AWS-L1</Task_Name>
-			<Task_Version>01.00</Task_Version>
-			<List_of_Inputs count="4">
-				<Input>
-					<File_Type>LOG</File_Type>
-					<File_Name_Type>Directory</File_Name_Type>
-					<List_of_File_Names count="1">
-						<File_Name></File_Name>
-					</List_of_File_Names>
-				</Input>
-				<Input>
-					<File_Type>IN</File_Type>
-					<File_Name_Type>Directory</File_Name_Type>
-					<List_of_File_Names count="1">
-						<File_Name></File_Name>
-					</List_of_File_Names>
-				</Input>
-				<Input>
-					<File_Type>SRC_AWS_00</File_Type>
-					<File_Name_Type>Physical</File_Name_Type>
-					<List_of_File_Names count="1">
-						<File_Name>test-data/outputs/W_XX-OHB-Stockholm,SAT,AWS1-MWR-00-SRC_C_OHB_20230822154844_G_D_20440115111111_20440115125434_T_B____.nc</File_Name>
-					</List_of_File_Names>
-				</Input>
-				<Input>
-					<File_Type>SRC_NAV_00</File_Type>
-					<File_Name_Type>Physical</File_Name_Type>
-					<List_of_File_Names count="1">
-						<File_Name>test-data/outputs/W_XX-OHB-Stockholm,SAT,AWS1-MWR-00-NAV_C_OHB_20230822154844_G_D_20440115111111_20440115125434_T_B____.nc</File_Name>
-					</List_of_File_Names>
-				</Input>
-			</List_of_Inputs>
-			<List_of_Outputs count="2">
-				<Output>
-					<File_Type>RAD_AWS_1B</File_Type>
-					<File_Name_Type>Directory</File_Name_Type>
-					<File_Name>/data/L1</File_Name>
-				</Output>
-				<Output>
-					<File_Type>TMP</File_Type>
-					<File_Name_Type>Directory</File_Name_Type>
-					<File_Name></File_Name>
-				</Output>
-			</List_of_Outputs>
-		</Ipf_Proc>
-	</List_of_Ipf_Procs>
+<?xml version="1.0" ?>
+<Ipf_Job_Order>
+  <Ipf_Conf>
+    <Processor_Name>IPF-AWS-L1</Processor_Name>
+    <Version>01.00</Version>
+    <Stdout_Log_Level>INFO</Stdout_Log_Level>
+    <Stderr_Log_Level>PROGRESS</Stderr_Log_Level>
+    <Test>false</Test>
+    <Breakpoint_Enable>false</Breakpoint_Enable>
+    <Processing_Station>SOD</Processing_Station>
+    <Config_Files count="1">
+      <Conf_File_Name>/opt/aws/conf/L1/AWS_L1_Configuration.xml</Conf_File_Name>
+    </Config_Files>
+    <Sensing_Time>
+      <Start>20250206_163403000000</Start>
+      <Stop>20250206_182403000000</Stop>
+    </Sensing_Time>
+  </Ipf_Conf>
+  <List_of_Ipf_Procs count="1">
+    <Ipf_Proc>
+      <Task_Name>IPF-AWS-L1</Task_Name>
+      <Task_Version>01.00</Task_Version>
+      <List_of_Inputs count="2">
+        <Input>
+          <File_Type>SRC_NAV_00</File_Type>
+          <File_Name_Type>Physical</File_Name_Type>
+          <List_of_File_Names count="1">
+            <File_Name>/home/mlange/Data/L0/20250206/SRC_NAV_00/W_XX-OHB-Stockholm,SAT,AWS1-NAV-00-SRC_C_OHB__20250207110422_G_D_20250206163403_20250206182403_T_B____.nc</File_Name>
+          </List_of_File_Names>
+        </Input>
+        <Input>
+          <File_Type>SRC_AWS_00</File_Type>
+          <File_Name_Type>Physical</File_Name_Type>
+          <List_of_File_Names count="1">
+            <File_Name>/home/mlange/Data/L0/20250206/SRC_AWS_00/W_XX-OHB-Stockholm,SAT,AWS1-MWR-00-SRC_C_OHB__20250207110422_G_D_20250206163403_20250206182403_T_B____.nc</File_Name>
+          </List_of_File_Names>
+        </Input>
+      </List_of_Inputs>
+      <List_of_Outputs count="1">
+        <Output>
+          <File_Type>RAD_AWS_1B</File_Type>
+          <File_Name_Type>Directory</File_Name_Type>
+          <File_Name>/data/L1</File_Name>
+        </Output>
+      </List_of_Outputs>
+    </Ipf_Proc>
+  </List_of_Ipf_Procs>
 </Ipf_Job_Order>

--- a/aws_pre_proc_container/entrypoint.sh
+++ b/aws_pre_proc_container/entrypoint.sh
@@ -14,12 +14,17 @@ L1_JOBORDER_TEMPLATE=/opt/aws/AWSat/JobOrder_L1_template.xml
 #    exit
 #fi
 
+cd ${RAW_INPUT_DIR}
+for f in *raw; do
+    python3.9 /opt/aws/bin/DSDB_VCID_replace.py $f --replace-vcid 3 2
+done
+
 cd /opt/aws/
 
 # Process RAW data to L0
-python3.9 AWSat/create_awsat_joborder.py -t $L0_JOBORDER_TEMPLATE -j $L0_JOBORDER -r $RAW_INPUT_DIR/*raw
-bin/IPF-AWS-L0 $L0_JOBORDER
+python3.9 /opt/aws/bin/create_awsat_joborder.py -t $L0_JOBORDER_TEMPLATE -j $L0_JOBORDER -r $RAW_INPUT_DIR/*raw
+/opt/aws/bin/IPF-AWS-L0 $L0_JOBORDER
 
 # Process L0 to L1
-python3.9 AWSat/create_awsat_joborder.py -t $L1_JOBORDER_TEMPLATE -j $L1_JOBORDER -0 $L0_OUTPUT_DIR/*SRC* -n $L0_OUTPUT_DIR/*NAV*
-bin/IPF-AWS-L1 $L1_JOBORDER
+python3.9 /opt/aws/bin/create_awsat_joborder.py -t $L1_JOBORDER_TEMPLATE -j $L1_JOBORDER -0 $L0_OUTPUT_DIR/*MWR* -n $L0_OUTPUT_DIR/*NAV*
+/opt/aws/bin/IPF-AWS-L1 $L1_JOBORDER


### PR DESCRIPTION
This PR updates the preprocessor container recipe to use IPF v3.1.1 and adds the VCID fixer to patch the raw data.